### PR TITLE
Remove "v" from perl version in META

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name" : "String::CamelCase",
   "source-url" : "git@github.com:yowcow/p6-String-CamelCase.git",
-  "perl" : "v6",
+  "perl" : "6",
   "resources" : [ ],
   "build-depends" : [ ],
   "provides" : {
@@ -13,7 +13,7 @@
     "Test",
     "Test::META"
   ],
-  "version" : "0.0.4",
+  "version" : "0.0.5",
   "authors" : [
     "yowcow"
   ]


### PR DESCRIPTION
Fix "Please remove leading 'v' from perl version in String::CamelCase's meta info."