### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,6 +6,7 @@
   "depends" : [ ],
   "description" : "Camelizes and decamelizes given string",
   "name" : "String::CamelCase",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "String::CamelCase" : "lib/String/CamelCase.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license