### PR TITLE
Fix seq in 2017.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: perl6
 perl6:
-  - "moar-2017.01"
-  - "moar-2017.04"
+  - "2017.01"
+  - "2017.04"
   - latest
 install:
   - rakudobrew build-panda

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: perl6
 perl6:
+  - "moar-2017.01"
+  - "moar-2017.04"
   - latest
 install:
   - rakudobrew build-panda

--- a/META6.json
+++ b/META6.json
@@ -17,5 +17,5 @@
     "Test",
     "Test::META"
   ],
-  "version" : "1.0.0"
+  "version" : "1.0.1"
 }

--- a/lib/String/CamelCase.pm6
+++ b/lib/String/CamelCase.pm6
@@ -30,7 +30,7 @@ our sub wordsplit(Str $given) is export(:DEFAULT) returns List {
         | "\b"
         | <?after <-[A ..Z]>> <?before <:Lu>>
         | <?after <:Lu>> <?before <:Lu> <:Ll>>
-    /, :skip-empty);
+    /, :skip-empty).cache;
 }
 
 =begin pod


### PR DESCRIPTION
`Str.split()` returns `Seq` where it used to return `List` starting from Perl 6 2017.04.