### PR TITLE
Fix META.json because it caused tests to fail

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -12,7 +12,7 @@
     "String::CamelCase" : "lib/String/CamelCase.pm6"
   },
   "resources" : [ ],
-  "source-url" : "git@github.com:yowcow/p6-String-CamelCase.git",
+  "source-url" : "https://github.com/yowcow/p6-String-CamelCase.git",
   "tags" : [
     "text",
     "string",


### PR DESCRIPTION
Also, it appears that the `https://` protocol is more acceptable nowadays.